### PR TITLE
Add integrations directory with provider stubs

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,10 @@
+# Integrations
+
+This directory contains connectors to external payment providers.
+
+## Adding a New Provider
+
+1. Create a subdirectory under `integrations/` named after the provider.
+2. Implement a `client.go` file that defines a `Client` struct and a `NewClient` constructor.
+3. Add methods for common operations such as `Charge` or `Refund`.
+4. Document configuration and usage details in a `README.md` inside the provider directory.

--- a/integrations/paypal/README.md
+++ b/integrations/paypal/README.md
@@ -1,0 +1,3 @@
+# PayPal Integration
+
+Minimal client for PayPal payments.

--- a/integrations/paypal/client.go
+++ b/integrations/paypal/client.go
@@ -1,0 +1,18 @@
+package paypal
+
+// Client is a minimal placeholder for interacting with the PayPal API.
+type Client struct {
+	ClientID     string
+	ClientSecret string
+}
+
+// NewClient returns a new PayPal client using the provided credentials.
+func NewClient(id, secret string) *Client {
+	return &Client{ClientID: id, ClientSecret: secret}
+}
+
+// Charge is a stub for creating a payment using PayPal.
+func (c *Client) Charge(amount float64, currency, source string) error {
+	// TODO: implement PayPal payment logic
+	return nil
+}

--- a/integrations/stripe/README.md
+++ b/integrations/stripe/README.md
@@ -1,0 +1,3 @@
+# Stripe Integration
+
+Minimal client for Stripe payments.

--- a/integrations/stripe/client.go
+++ b/integrations/stripe/client.go
@@ -1,0 +1,17 @@
+package stripe
+
+// Client is a minimal placeholder for interacting with the Stripe API.
+type Client struct {
+	APIKey string
+}
+
+// NewClient returns a new Stripe client with the provided API key.
+func NewClient(apiKey string) *Client {
+	return &Client{APIKey: apiKey}
+}
+
+// Charge is a stub for creating a charge using Stripe.
+func (c *Client) Charge(amount int64, currency, source string) error {
+	// TODO: implement Stripe charge logic
+	return nil
+}

--- a/project_structure.md
+++ b/project_structure.md
@@ -11,6 +11,7 @@ Amanah/
 ├── configs/           # Configuration files for different environments
 ├── deployments/       # Deployment scripts and manifests
 ├── docs/              # Documentation for the project
+├── integrations/      # Connectors to external payment providers
 ├── tests/             # End-to-end and integration tests
 ├── scripts/           # Automation and utility scripts
 └── README.md          # Project overview and instructions
@@ -75,6 +76,15 @@ docs/
 ├── api.md              # API documentation
 ├── setup.md            # Setup and installation instructions
 └── README.md           # Documentation index
+```
+
+### `integrations/`
+Connectors to external payment providers:
+```
+integrations/
+├── stripe/             # Stripe client implementation
+├── paypal/             # PayPal client implementation
+└── README.md           # Connector guidelines
 ```
 
 ### `tests/`


### PR DESCRIPTION
## Summary
- introduce a new `integrations/` directory
- add Stripe and PayPal client stubs
- document how to create connectors
- mention integrations directory in project docs

## Testing
- `go vet ./...`

## Summary by Sourcery

Introduce a new integrations directory containing stub clients for Stripe and PayPal along with guidelines for adding provider connectors.

New Features:
- Add stub implementations for Stripe and PayPal payment clients.

Enhancements:
- Create integrations directory to organize external payment provider connectors.
- Provide README guidelines for adding and configuring new provider integrations.

Documentation:
- Update project structure documentation to include the integrations directory.
- Add README files for the integrations directory and each provider subdirectory.