### PR TITLE
Update README with Docker Compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ The project follows a microservices architecture to ensure modularity and scalab
 1. Clone the repository: `git clone <repository-url>`
 2. Set up the project structure as defined in `project_structure.md`.
 3. Install dependencies and configure environment variables.
-4. Run the services using Docker or Kubernetes.
+4. Run the services using Docker Compose:
+   ```bash
+   docker-compose up --build
+   ```
+   This command starts the application along with Redis and any other services defined in `docker-compose.yml`.
 
 ## Documentation
-- Refer to `docs/` for detailed documentation on architecture, APIs, and setup instructions.
+- See `docs/architecture.md` for an overview of the system design and `docs/api.md` for API details. Additional documentation is available in the `docs/` directory.
 - Use `project_structure.md` for understanding the directory layout and service organization.
 
 ## Contributing

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,9 @@
+# API Overview
+
+This document summarizes the main API endpoints available in Amanah.
+
+## Transaction Service
+- `POST /transactions` - Create a new transaction
+- `GET /transactions/{id}` - Retrieve transaction status
+
+Additional services provide their own APIs. Refer to each service's README for details.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,10 @@
+# Architecture Overview
+
+Amanah is organized around a microservices design. Each service focuses on a specific domain and runs independently.
+
+## Core Services
+- **Transaction Service**: Manages the lifecycle of financial transactions.
+- **Notification Service**: Handles delivery of emails, SMS, and other alerts.
+- **Support Services**: Components such as Redis are used for caching and message brokering.
+
+Services communicate via HTTP and message queues. They can be started together locally using Docker Compose.


### PR DESCRIPTION
## Summary
- document running multiple services with `docker-compose`
- add docs on the architecture and API
- reference the new docs in README

## Testing
- `go test ./...`
- `go vet ./...`

## Summary by Sourcery

Update README to document running services with Docker Compose and reference new documentation, and add architecture and API overview documents.

Documentation:
- Document running services using Docker Compose in README and reference the new docs
- Add docs/architecture.md with an overview of the microservices architecture
- Add docs/api.md summarizing the main API endpoints