### PR TITLE
Add basic authentication service

### DIFF
--- a/services/authentication/README.md
+++ b/services/authentication/README.md
@@ -1,3 +1,7 @@
 # Authentication Service
 
-This service manages user authentication, including login and token generation.
+This service manages user authentication. It exposes a `/login` endpoint that
+accepts a JSON payload containing a username and password. On successful
+authentication it returns a short lived token generated using the shared
+`libs/auth` package. A simple in-memory repository is used for storing users and
+is initialized with a default `admin` user when the service starts.

--- a/services/authentication/cmd/main.go
+++ b/services/authentication/cmd/main.go
@@ -4,6 +4,12 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+	"amanah/libs/auth"
+	"amanah/services/authentication/handlers"
+	"amanah/services/authentication/models"
+	"amanah/services/authentication/repositories"
+	svc "amanah/services/authentication/services"
 )
 
 func main() {
@@ -11,6 +17,15 @@ func main() {
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "OK")
 	})
+
+	// simple in-memory setup with a single user
+	repo := repositories.NewInMemoryUserRepo()
+	repo.AddUser(models.User{ID: "1", Username: "admin", Password: "password"})
+
+	tokenMgr := auth.NewManager()
+	service := svc.NewAuthService(repo, tokenMgr)
+
+	mux.Handle("/login", handlers.LoginHandler(service))
 
 	addr := ":8080"
 	log.Printf("authentication service listening on %s", addr)

--- a/services/authentication/handlers/login.go
+++ b/services/authentication/handlers/login.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"amanah/libs/logging"
+	"amanah/services/authentication/services"
+)
+
+// LoginRequest is the expected payload for login.
+type LoginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// LoginResponse represents the response containing the auth token.
+type LoginResponse struct {
+	Token string `json:"token"`
+}
+
+// LoginHandler returns an HTTP handler for logging in.
+func LoginHandler(svc *services.AuthService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req LoginRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		token, err := svc.Login(req.Username, req.Password)
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		logging.Info("user %s logged in", req.Username)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(LoginResponse{Token: token})
+	}
+}

--- a/services/authentication/models/user.go
+++ b/services/authentication/models/user.go
@@ -1,0 +1,8 @@
+package models
+
+// User represents an application user.
+type User struct {
+	ID       string
+	Username string
+	Password string
+}

--- a/services/authentication/repositories/inmemory.go
+++ b/services/authentication/repositories/inmemory.go
@@ -1,0 +1,24 @@
+package repositories
+
+import "amanah/services/authentication/models"
+
+// InMemoryUserRepo provides an in-memory user store.
+type InMemoryUserRepo struct {
+	users map[string]models.User // username -> user
+}
+
+// NewInMemoryUserRepo creates a repository with the provided initial users.
+func NewInMemoryUserRepo() *InMemoryUserRepo {
+	return &InMemoryUserRepo{users: make(map[string]models.User)}
+}
+
+// AddUser stores a user in the repo.
+func (r *InMemoryUserRepo) AddUser(u models.User) {
+	r.users[u.Username] = u
+}
+
+// GetByUsername returns a user by username and a boolean flag if found.
+func (r *InMemoryUserRepo) GetByUsername(username string) (models.User, bool) {
+	u, ok := r.users[username]
+	return u, ok
+}

--- a/services/authentication/services/auth.go
+++ b/services/authentication/services/auth.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"errors"
+
+	"amanah/libs/auth"
+	"amanah/services/authentication/repositories"
+)
+
+// AuthService handles user authentication and token generation.
+type AuthService struct {
+	repo   *repositories.InMemoryUserRepo
+	tokens *auth.Manager
+}
+
+// NewAuthService creates a new AuthService.
+func NewAuthService(repo *repositories.InMemoryUserRepo, tokens *auth.Manager) *AuthService {
+	return &AuthService{repo: repo, tokens: tokens}
+}
+
+// Login validates credentials and returns a token.
+func (s *AuthService) Login(username, password string) (string, error) {
+	user, ok := s.repo.GetByUsername(username)
+	if !ok || user.Password != password {
+		return "", errors.New("invalid credentials")
+	}
+	return s.tokens.GenerateToken(user.ID)
+}

--- a/services/authentication/services/auth_test.go
+++ b/services/authentication/services/auth_test.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"testing"
+
+	"amanah/libs/auth"
+	"amanah/services/authentication/models"
+	"amanah/services/authentication/repositories"
+)
+
+func TestAuthServiceLogin(t *testing.T) {
+	repo := repositories.NewInMemoryUserRepo()
+	repo.AddUser(models.User{ID: "1", Username: "user", Password: "secret"})
+
+	svc := NewAuthService(repo, auth.NewManager())
+
+	token, err := svc.Login("user", "secret")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if token == "" {
+		t.Fatalf("expected token, got empty string")
+	}
+
+	if _, err := svc.Login("user", "wrong"); err == nil {
+		t.Fatalf("expected error for wrong password")
+	}
+}


### PR DESCRIPTION
## Summary
- implement minimal authentication service
- add in-memory user repo and auth service
- provide login handler and register it in main
- document authentication service in README
- add basic unit test for authentication login

## Testing
- `go vet ./...`
- `go test ./...`

## Summary by Sourcery

Implement a minimal authentication service exposing a `/login` endpoint backed by an in-memory user repository seeded with a default admin user and generating tokens via the shared `libs/auth` package.

New Features:
- Add AuthService with a `Login` method that validates credentials and returns a token
- Introduce an in-memory user repository and seed it with a default `admin` user in `main`
- Implement an HTTP `LoginHandler` for the `/login` endpoint that accepts JSON credentials and returns a token

Enhancements:
- Log successful login events

Documentation:
- Document the `/login` endpoint, token generation, and default admin user setup in the service README

Tests:
- Add unit tests for `AuthService.Login` covering successful and failed login scenarios